### PR TITLE
Rework build steps.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,35 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.DS_Store
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/bin
+**/charts
+**/docker-compose*
+**/compose*
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+LICENSE
+README.md
 config.json
 config.toml
 .env

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -44,8 +44,6 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@v5.3.0
         with:
-          context: .
-          file: airbot/Dockerfile
           push: false
 
   lint:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,8 +46,6 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.3.0
         with:
-          context: .
-          file: airbot/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,64 @@
-FROM golang:1.22
+# syntax=docker/dockerfile:1
 
-WORKDIR /go/src/github.com/airforce270
+# https://docs.docker.com/go/dockerfile-reference/
 
-# To use local copies of dependencies (for development), run the copy here.
-# For example:
-# COPY helix/. ./helix
+# Create a stage for building the application.
+ARG GO_VERSION=1.22.0
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS build
+WORKDIR /src
 
-WORKDIR /go/src/github.com/airforce270/airbot
+# Download dependencies as a separate step to take advantage of Docker's caching.
+# Leverage a cache mount to /go/pkg/mod/ to speed up subsequent builds.
+# Leverage bind mounts to go.sum and go.mod to avoid having to copy them into
+# the container.
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=go.mod,target=go.mod \
+    go mod download -x
 
-# pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
-COPY airbot/go.mod airbot/go.sum ./
-RUN go mod download && go mod verify
+# This is the architecture you’re building for, which is passed in by the builder.
+# Placing it here allows the previous steps to be cached across architectures.
+ARG TARGETARCH
 
-COPY airbot/. .
-RUN go build -v -o airbot/build/airbot
+# Build the application.
+# Leverage a cache mount to /go/pkg/mod/ to speed up subsequent builds.
+# Leverage a bind mount to the current directory to avoid having to copy the
+# source code into the container.
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=bind,target=. \
+    CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o /bin/server .
 
-ENTRYPOINT ["airbot/build/airbot"]
+################################################################################
+# Create a new stage for running the application that contains the minimal
+# runtime dependencies for the application. This often uses a different base
+# image from the build stage where the necessary files are copied from the build
+# stage.
+FROM alpine:3 AS final
+
+# Install any runtime dependencies that are needed to run your application.
+# Leverage a cache mount to /var/cache/apk/ to speed up subsequent builds.
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk --update add \
+    ca-certificates \
+    tzdata \
+    && \
+    update-ca-certificates
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
+USER appuser
+
+# Copy the executable from the "build" stage.
+COPY --from=build /bin/server /bin/
+
+# What the container should run when it is started.
+ENTRYPOINT [ "/bin/server" ]

--- a/commands/basecommand/basecommand.go
+++ b/commands/basecommand/basecommand.go
@@ -64,15 +64,16 @@ func (c *Command) Compile() (*regexp.Regexp, error) {
 
 // Usage returns usage information for the command.
 func (c *Command) Usage(prefix string) string {
-	parts := []string{prefix + c.Name}
+	var resp strings.Builder
+	resp.WriteString(prefix + c.Name)
 	for _, arg := range c.Params {
 		if arg.Required {
-			parts = append(parts, fmt.Sprintf("<%s>", arg.UsageForDocString()))
+			fmt.Fprintf(&resp, " <%s>", arg.UsageForDocString())
 		} else {
-			parts = append(parts, fmt.Sprintf("[%s]", arg.UsageForDocString()))
+			fmt.Fprintf(&resp, " [%s]", arg.UsageForDocString())
 		}
 	}
-	return strings.Join(parts, " ")
+	return resp.String()
 }
 
 // Help returns help information for the command.

--- a/commands/botinfo/botinfo.go
+++ b/commands/botinfo/botinfo.go
@@ -29,9 +29,9 @@ var Commands = [...]basecommand.Command{
 		Permission: permission.Normal,
 		Handler: func(msg *base.IncomingMessage, args []arg.Arg) ([]*base.Message, error) {
 			var resp strings.Builder
-			resp.WriteString(fmt.Sprintf("Beep boop, this is Airbot running as %s in %s", msg.Resources.Platform.Username(), msg.Message.Channel))
-			resp.WriteString(fmt.Sprintf(" with prefix %s on %s.", msg.Prefix, msg.Resources.Platform.Name()))
-			resp.WriteString(fmt.Sprintf(" Made by airforce2700, source available on GitHub ( %ssource )", msg.Prefix))
+			fmt.Fprintf(&resp, "Beep boop, this is Airbot running as %s in %s", msg.Resources.Platform.Username(), msg.Message.Channel)
+			fmt.Fprintf(&resp, " with prefix %s on %s.", msg.Prefix, msg.Resources.Platform.Name())
+			fmt.Fprintf(&resp, " Made by airforce2700, source available on GitHub ( %ssource )", msg.Prefix)
 			return []*base.Message{
 				{
 					Channel: msg.Message.Channel,

--- a/commands/kick/kick.go
+++ b/commands/kick/kick.go
@@ -63,7 +63,7 @@ func isLive(msg *base.IncomingMessage, args []arg.Arg) ([]*base.Message, error) 
 	if channel.Livestream != nil {
 		resp.WriteString(" is currently live on Kick, ")
 		category := channel.Livestream.Categories[0]
-		resp.WriteString(fmt.Sprintf("streaming %s to %d viewers.", category.DisplayName, channel.Livestream.ViewerCount))
+		fmt.Fprintf(&resp, "streaming %s to %d viewers.", category.DisplayName, channel.Livestream.ViewerCount)
 	} else {
 		resp.WriteString(" is not currently live on Kick.")
 	}

--- a/commands/twitch/twitch.go
+++ b/commands/twitch/twitch.go
@@ -373,12 +373,12 @@ func subAge(msg *base.IncomingMessage, args []arg.Arg) ([]*base.Message, error) 
 
 		var outMsg strings.Builder
 		outMsg.WriteString(sub.User.DisplayName + " is currently subscribed to " + sub.Channel.DisplayName)
-		outMsg.WriteString(fmt.Sprintf(" with a %s subscription", tier))
-		outMsg.WriteString(fmt.Sprintf(" (%d %s remaining)", sub.Streak.DaysRemaining, plural("day", sub.Streak.DaysRemaining)))
-		outMsg.WriteString(fmt.Sprintf(" and is on a %d month streak", sub.Streak.Months))
+		fmt.Fprintf(&outMsg, " with a %s subscription", tier)
+		fmt.Fprintf(&outMsg, " (%d %s remaining)", sub.Streak.DaysRemaining, plural("day", sub.Streak.DaysRemaining))
+		fmt.Fprintf(&outMsg, " and is on a %d month streak", sub.Streak.Months)
 
 		if sub.Cumulative.Months > sub.Streak.Months {
-			outMsg.WriteString(fmt.Sprintf(" (total: %d %s)", sub.Cumulative.Months, plural("month", sub.Cumulative.Months)))
+			fmt.Fprintf(&outMsg, " (total: %d %s)", sub.Cumulative.Months, plural("month", sub.Cumulative.Months))
 		}
 
 		return []*base.Message{{Channel: msg.Message.Channel, Text: outMsg.String()}}, nil

--- a/config/config.go
+++ b/config/config.go
@@ -11,13 +11,13 @@ import (
 )
 
 // fileName contains the name of the config file to be read (when referenced by the binary).
-const fileName = "config.toml"
+const filePath = "/config.toml"
 
 // DefaultNewConfigSource is the default source of the latest config data.
 var DefaultNewConfigSource = func() (io.ReadCloser, error) {
-	f, err := os.Open(fileName)
+	f, err := os.Open(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open %q: %w", fileName, err)
+		return nil, fmt.Errorf("failed to open %q: %w", filePath, err)
 	}
 	return f, nil
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,8 @@
 services:
   server:
-    image: ghcr.io/airforce270/airbot:release
+    build:
+      context: .
+      target: final
     env_file: .env
     environment:
       - RUNNING_IN_DOCKER=true
@@ -10,4 +12,6 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - ./config.toml:/go/src/github.com/airforce270/airbot/config.toml
+      - type: bind
+        source: ./config.toml
+        target: /config.toml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,17 @@
+# https://docs.docker.com/go/compose-spec-reference/
+# https://github.com/docker/awesome-compose
+
 services:
   database:
     image: postgres:15
     restart: always
     env_file: .env
-    ports:
-      - "5432:5432"
+    expose:
+      - 5432
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
+      test: [ "CMD", "pg_isready" ]
       interval: 1s
       timeout: 5s
       retries: 10
@@ -17,15 +20,19 @@ services:
     restart: always
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
-    ports:
-      - '6379:6379'
+    expose:
+      - 6379
     command: redis-server --save 30 1
     volumes:
       - redis-data:/data
   server:
     build:
-      context: ../
-      dockerfile: airbot/Dockerfile
+      context: .
+      target: final
+    develop:
+      watch:
+        - action: rebuild
+          path: ./
     env_file: .env
     environment:
       - RUNNING_IN_DOCKER=true
@@ -33,7 +40,9 @@ services:
       database:
         condition: service_healthy
     volumes:
-      - ./config.toml:/go/src/github.com/airforce270/airbot/config.toml
+      - type: bind
+        source: ./config.toml
+        target: /config.toml
 volumes:
   postgres-data:
     name: airbot_postgres-15-data

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-docker compose up --build
+docker compose watch
+docker compose down


### PR DESCRIPTION
- Use `docker init` to apply best practices to Dockerfile and compose file
- Use `docker compose watch` for local runs
- Small cleanups for string builders